### PR TITLE
Refactor MIDI player into modular package

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,27 @@ pip install -r requirements.txt
 ```bash
 python synth_intro.py
 ```
+## MIDI Player
+
+This project also contains a 32‑voice MIDI softsynth. The code has been split into
+separate modules located in the `midiplayer` package:
+
+- `instruments.py` – basic DSP routines and instrument generators.
+- `player.py` – MIDI parsing, rendering, and playback logic.
+- `cli.py` – command line argument parsing.
+
+Use the `midi_player.py` script to render MIDI files or play a test tone. Running the
+script without any arguments shows the available options:
+
+```bash
+python midi_player.py
+```
+
+To render a MIDI file:
+
+```bash
+python midi_player.py --midi path/to/song.mid
+```
+
+The output lists available audio devices, plays the file through PyAudio and can also
+save the result as `midi_synth32.wav` when `--save` is provided.

--- a/midi_player.py
+++ b/midi_player.py
@@ -1,0 +1,16 @@
+import sys
+
+from midiplayer.cli import get_parser
+from midiplayer import player
+
+def main() -> None:
+    parser = get_parser()
+    if len(sys.argv) == 1:
+        parser.print_help()
+        return
+    args = parser.parse_args()
+    player.run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/midiplayer/cli.py
+++ b/midiplayer/cli.py
@@ -1,0 +1,32 @@
+import argparse
+
+
+def get_parser() -> argparse.ArgumentParser:
+    """Build and return the command line argument parser."""
+    ap = argparse.ArgumentParser(
+        description="32‑voice MIDI softsynth with PyAudio playback (quiet)."
+    )
+    ap.add_argument("--midi", help="Path to a legally obtained MIDI file to render.")
+    ap.add_argument("--frames", type=int, default=2048, help="Frames per buffer for streaming (PyAudio).")
+    ap.add_argument("--device-index", type=int, default=None, help="PyAudio output device index.")
+    ap.add_argument("--device-name", type=str, default=None, help="Substring to select device (e.g., 'pulse').")
+    ap.add_argument("--poly", type=int, default=32, help="Max pitched voices per 20ms window (drums excluded).")
+    ap.add_argument("--gain", type=float, default=0.90, help="Master gain multiplier after normalization.")
+    ap.add_argument("--save", action="store_true", help="Also save rendered WAV (midi_synth32.wav).")
+    ap.add_argument("--progress", action="store_true", help="Show progress on stderr.")
+    ap.add_argument("--preview", type=float, default=0.0, help="Render only the first N seconds (0 = full song).")
+    ap.add_argument("--test-tone", action="store_true", help="Play a 2s test tone instead of MIDI.")
+    ap.add_argument("--tail", type=float, default=2.0, help="Extra seconds after the last musical event.")
+    ap.add_argument(
+        "--max-note-dur", type=float, default=30.0,
+        help="Clamp any single note duration (0 disables)."
+    )
+    ap.add_argument(
+        "--realtime", action="store_true",
+        help="Play in realtime with prebuffered chunks (no DSP simplifications)."
+    )
+    ap.add_argument(
+        "--prebuffer", type=float, default=3.0,
+        help="Seconds of audio to prebuffer/look-ahead in realtime mode."
+    )
+    return ap

--- a/midiplayer/instruments.py
+++ b/midiplayer/instruments.py
@@ -1,0 +1,264 @@
+import numpy as np
+
+def midi_to_freq(m): return 440.0 * (2.0 ** ((m - 69) / 12.0))
+
+def one_pole_lp(x, cutoff_hz_arr, sr):
+    y = np.zeros_like(x, dtype=np.float32); z = 0.0; twopi = 2.0 * np.pi
+    for i in range(len(x)):
+        fc = float(cutoff_hz_arr[i])
+        fc = 20.0 if fc < 20.0 else (sr/2 - 200.0 if fc > (sr/2 - 200.0) else fc)
+        alpha = (twopi * fc) / (twopi * fc + sr)
+        z += alpha * (x[i] - z); y[i] = z
+    return y
+
+def one_pole_hp(x, cutoff_hz, sr):
+    c = np.full_like(x, float(cutoff_hz), dtype=np.float32)
+    return x - one_pole_lp(x, c, sr)
+
+def soft_clip_tanh(x, drive=2.5):
+    return np.tanh(x * drive).astype(np.float32) / np.tanh(float(drive))
+
+# ------------------------------ oscillators -----------------------------------
+def osc_saw(freq_arr, sr):
+    # Phase-integrated saw with simple wrap (aliased but light/fast)
+    phase = np.cumsum(2*np.pi*freq_arr/sr, dtype=np.float32)
+    saw = 2.0*(phase/(2*np.pi) - np.floor(0.5 + phase/(2*np.pi)))
+    return saw.astype(np.float32)
+
+def osc_square(freq_arr, sr):
+    phase = np.cumsum(2*np.pi*freq_arr/sr, dtype=np.float32)
+    return np.sign(np.sin(phase)).astype(np.float32)
+
+def osc_sine(freq_arr, sr):
+    phase = np.cumsum(2*np.pi*freq_arr/sr, dtype=np.float32)
+    return np.sin(phase).astype(np.float32)
+
+# ------------------------------ envelopes -------------------------------------
+def adsr(n_on, sr, a=0.005, d=0.12, s=0.65, r=0.25):
+    """ADSR safe for very short notes (n_on can be < a+d). Release starts at note-off."""
+    a_n = max(1, int(round(a*sr)))
+    d_n = max(1, int(round(d*sr)))
+    r_n = max(1, int(round(r*sr)))
+
+    env = np.zeros(n_on + r_n, dtype=np.float32)
+
+    # Attack (partial if needed)
+    nA = min(a_n, n_on)
+    if nA > 0:
+        env[:nA] = np.linspace(0.0, 1.0, nA, endpoint=False, dtype=np.float32)
+    pos = nA
+
+    # Decay (partial if needed)
+    if pos < n_on:
+        nD = min(d_n, n_on - pos)
+        if nD > 0:
+            decay_full = np.linspace(1.0, s, d_n, endpoint=False, dtype=np.float32)
+            env[pos:pos+nD] = decay_full[:nD]
+            pos += nD
+
+    # Sustain
+    if pos < n_on:
+        env[pos:n_on] = s
+        pos = n_on
+
+    # Release from current level
+    rel_level = float(env[n_on - 1]) if n_on > 0 else 0.0
+    env[n_on:n_on + r_n] = np.linspace(rel_level, 0.0, r_n, endpoint=False, dtype=np.float32)
+    return env
+
+# ------------------------------ instruments -----------------------------------
+def synth_tone(freq, dur, sr, *,
+               osc='saw', detune_cents=6.0,
+               cutoff_start=7000.0, cutoff_end=2200.0,
+               a=0.005, d=0.12, s=0.65, r=0.25,
+               vibrato_hz=0.0, vibrato_cents=0.0,
+               drive=0.0, amp=0.5):
+    """Detuned dual-osc -> LP sweep -> ADSR -> optional drive. Returns mono float32."""
+    n_on = int(max(1, round(dur*sr)))
+    env = adsr(n_on, sr, a=a, d=d, s=s, r=r)
+    n_total = len(env)
+    t = np.arange(n_total, dtype=np.float32)/sr
+
+    # Vibrato
+    if vibrato_hz > 0.0 and vibrato_cents > 0.0:
+        vib = np.sin(2*np.pi*vibrato_hz*t).astype(np.float32) * float(vibrato_cents)
+        vib_fac = (2.0 ** (vib/1200.0)).astype(np.float32)
+    else:
+        vib_fac = 1.0
+
+    det = 2.0 ** (detune_cents/1200.0)
+    f1 = np.full(n_total, float(freq), dtype=np.float32)
+    f2 = np.full(n_total, float(freq*det), dtype=np.float32)
+    if isinstance(vib_fac, np.ndarray):
+        f1 *= vib_fac; f2 *= vib_fac
+
+    if osc == 'square':
+        x1 = osc_square(f1, sr); x2 = osc_square(f2, sr)
+    elif osc == 'sine':
+        x1 = osc_sine(f1, sr);   x2 = osc_sine(f2, sr)
+    else:
+        x1 = osc_saw(f1, sr);    x2 = osc_saw(f2, sr)
+
+    raw = (0.6*x1 + 0.4*x2).astype(np.float32)
+
+    # LP sweep
+    c_env = np.linspace(float(cutoff_start), float(cutoff_end), n_total, dtype=np.float32)
+    y = one_pole_lp(raw, c_env, sr)
+
+    # Drive
+    if drive and drive > 0.0:
+        y = soft_clip_tanh(y, drive=drive)
+
+    out = (y * env * float(amp)).astype(np.float32)
+    return out
+
+def synth_bass_note(freq, dur, sr, amp=0.35):
+    """Detuned square -> LP ~400 Hz, short decay."""
+    n = int(max(1, dur*sr)); t = np.arange(n, dtype=np.float32)/sr
+    sq1 = np.sign(np.sin(2*np.pi*freq*t)).astype(np.float32)
+    sq2 = np.sign(np.sin(2*np.pi*freq*1.01*t)).astype(np.float32)
+    x = 0.6*sq1 + 0.4*sq2
+    env = np.exp(-t*6.0).astype(np.float32)
+    x = x * env
+    cutoff = np.full(n, 400.0, dtype=np.float32)
+    y = one_pole_lp(x, cutoff, sr)
+    return (y * float(amp)).astype(np.float32)
+
+# ---- Drums ----
+def synth_kick(sr, dur=0.22, amp=0.9):
+    n = int(max(1, dur*sr)); t = np.arange(n, dtype=np.float32)/sr
+    f_start, f_end, k = 120.0, 45.0, 20.0
+    f = f_end + (f_start - f_end) * np.exp(-k*t)
+    phase = np.cumsum(2*np.pi*f/sr, dtype=np.float32)
+    body = np.sin(phase).astype(np.float32)
+    env = np.exp(-t*28.0).astype(np.float32)
+    click = (np.exp(-t*2000.0)*0.5).astype(np.float32)
+    sig = body*env + click
+    return (sig * float(amp)).astype(np.float32)
+
+def synth_snare(sr, dur=0.18, amp=0.4):
+    n = int(max(1, dur*sr)); t = np.arange(n, dtype=np.float32)/sr
+    noise = (np.random.rand(n).astype(np.float32)*2.0 - 1.0)
+    noise = one_pole_hp(noise, 1800.0, sr)
+    tone = np.sin(2*np.pi*190.0*t).astype(np.float32) * np.exp(-t*30.0)
+    env = np.exp(-t*40.0).astype(np.float32)
+    sig = 0.85*noise*env + 0.15*tone
+    return (sig * float(amp)).astype(np.float32)
+
+def synth_hat(sr, dur=0.06, amp=0.22, open_=False):
+    n = int(max(1, dur*sr)); t = np.arange(n, dtype=np.float32)/sr
+    noise = (np.random.rand(n).astype(np.float32)*2.0 - 1.0)
+    noise = one_pole_hp(noise, 6500.0, sr)
+    decay = 50.0 if open_ else 120.0
+    env = np.exp(-t*decay).astype(np.float32)
+    sig = noise * env
+    return (sig * float(amp)).astype(np.float32)
+
+def synth_tom(sr, base_hz=120.0, dur=0.25, amp=0.45):
+    n = int(max(1, dur*sr)); t = np.arange(n, dtype=np.float32)/sr
+    f = base_hz + 10*np.exp(-15.0*t)
+    phase = np.cumsum(2*np.pi*f/sr, dtype=np.float32)
+    tone = np.sin(phase).astype(np.float32)
+    tone *= np.exp(-t*12.0).astype(np.float32)
+    attack = (np.random.rand(n).astype(np.float32)*2.0 - 1.0)
+    attack = one_pole_hp(attack, 3000.0, sr) * np.exp(-t*200.0).astype(np.float32) * 0.2
+    return ((tone + attack) * float(amp)).astype(np.float32)
+
+def synth_crash(sr, dur=1.8, amp=0.25):
+    n = int(max(1, dur*sr)); t = np.arange(n, dtype=np.float32)/sr
+    noise = (np.random.rand(n).astype(np.float32)*2.0 - 1.0)
+    noise = one_pole_hp(noise, 4000.0, sr)
+    env = np.exp(-t*2.2).astype(np.float32)
+    sig = noise * env
+    return (sig * float(amp)).astype(np.float32)
+
+# ------------------------------- mixing utils --------------------------------
+def mix_mono(stereo, start, sig, pan=0.0):
+    """Mix mono into stereo buffer at 'start' with simple pan; clamps to buffer (no extension)."""
+    if start >= stereo.shape[1]:
+        return stereo
+    pan = float(max(-1.0, min(1.0, pan)))
+    lg = 0.5*(1.0 - pan); rg = 0.5*(1.0 + pan)
+    end = min(start + len(sig), stereo.shape[1])
+    seg = sig[:max(0, end - start)]
+    stereo[0, start:end] += seg * lg
+    stereo[1, start:end] += seg * rg
+    return stereo
+
+def stereo_cross_delay_offline(stereo, sr, delay_s=0.24, mix=0.18):
+    d = max(1,int(delay_s*sr)); out = stereo.copy()
+    if d < out.shape[1]:
+        out[0, d:] += mix*stereo[1, :-d]; out[1, d:] += mix*stereo[0, :-d]
+    return out
+
+class CrossDelayState:
+    """Streaming version of the cross-delay that exactly matches the offline effect."""
+    def __init__(self, sr, delay_s=0.24, mix=0.18):
+        self.d = max(0, int(round(delay_s*sr)))
+        self.mix = float(mix)
+        self.rL = np.zeros(self.d, dtype=np.float32) if self.d > 0 else None
+        self.rR = np.zeros(self.d, dtype=np.float32) if self.d > 0 else None
+
+    def apply(self, dryL, dryR):
+        if self.d == 0:
+            return dryL.copy(), dryR.copy()
+        n = dryL.shape[0]
+        wetL = dryL.copy()
+        wetR = dryR.copy()
+
+        # Cross from R->L and L->R
+        k = min(self.d, n)
+        # Begin of chunk: pull from ring (previous chunk history)
+        wetL[:k] += self.mix * self.rR[:k]
+        wetR[:k] += self.mix * self.rL[:k]
+        # Remainder of chunk: cross-feed inside the same chunk
+def program_to_inst(prog):
+    """Return a compact instrument 'tag' based on GM program (0..127)."""
+    p = int(prog)
+    if p in (29, 30):            # Overdriven/Distortion Guitar
+        return 'dist_gtr'
+    if 24 <= p <= 31:            # Guitars
+        return 'clean_gtr'
+    if 32 <= p <= 39:            # Basses
+        return 'bass'
+    if 40 <= p <= 51:            # Solo strings + ensemble
+        return 'strings'
+    if 80 <= p <= 87:            # Leads (square/saw)
+        return 'lead'
+    if p == 56:                  # Harp
+        return 'pluck'
+    return 'piano'               # default
+
+def inst_params(tag, vel=100):
+    """Map instrument tag to synth parameters (coarse but musical)."""
+    v = max(1, min(127, int(vel)))
+    vsc = (v/127.0) ** 1.4  # perceptual-ish velocity curve
+    if tag == 'piano':
+        return dict(osc='saw', detune_cents=5.0,
+                    cutoff_start=5200.0, cutoff_end=900.0,
+                    a=0.003, d=0.22, s=0.55, r=0.6, drive=0.0, amp=0.55*vsc)
+    if tag == 'clean_gtr':
+        return dict(osc='square', detune_cents=4.0,
+                    cutoff_start=6000.0, cutoff_end=1800.0,
+                    a=0.004, d=0.12, s=0.60, r=0.35, drive=0.0, amp=0.5*vsc)
+    if tag == 'dist_gtr':
+        return dict(osc='saw', detune_cents=6.0,
+                    cutoff_start=7000.0, cutoff_end=2200.0,
+                    a=0.004, d=0.10, s=0.70, r=0.42, drive=3.2, amp=0.48*vsc)
+    if tag == 'strings':
+        return dict(osc='saw', detune_cents=9.0,
+                    cutoff_start=7500.0, cutoff_end=2500.0,
+                    a=0.045, d=0.40, s=0.90, r=1.6, drive=0.0, amp=0.42*vsc)
+    if tag == 'lead':
+        return dict(osc='saw', detune_cents=3.0,
+                    cutoff_start=6800.0, cutoff_end=1700.0,
+                    a=0.006, d=0.10, s=0.65, r=0.45, drive=1.0, amp=0.5*vsc)
+    if tag == 'pluck':
+        return dict(osc='saw', detune_cents=4.0,
+                    cutoff_start=5400.0, cutoff_end=1200.0,
+                    a=0.002, d=0.18, s=0.40, r=0.25, drive=0.0, amp=0.5*vsc)
+    # fallback
+    return dict(osc='saw', detune_cents=6.0,
+                cutoff_start=6500.0, cutoff_end=2000.0,
+                a=0.005, d=0.12, s=0.65, r=0.35, drive=0.0, amp=0.5*vsc)
+

--- a/midiplayer/player.py
+++ b/midiplayer/player.py
@@ -14,7 +14,6 @@
 #             CC120 (All Sound Off), CC123 (All Notes Off), CC121 (Reset All Controllers).
 # - Channel 10 (index 9) is treated as GM drums.
 
-import argparse
 import os
 import sys
 import time
@@ -24,6 +23,12 @@ from collections import deque
 import numpy as np
 import pyaudio
 import wave
+from .instruments import (
+    midi_to_freq, synth_tone, synth_bass_note, synth_kick, synth_snare,
+    synth_hat, synth_tom, synth_crash, mix_mono, stereo_cross_delay_offline,
+    CrossDelayState, program_to_inst, inst_params
+)
+
 
 # ---- MIDI import ----
 try:
@@ -54,218 +59,6 @@ class capture_stderr:
         self._tmp.close()
 
 # ------------------------------ DSP primitives --------------------------------
-def midi_to_freq(m): return 440.0 * (2.0 ** ((m - 69) / 12.0))
-
-def one_pole_lp(x, cutoff_hz_arr, sr):
-    y = np.zeros_like(x, dtype=np.float32); z = 0.0; twopi = 2.0 * np.pi
-    for i in range(len(x)):
-        fc = float(cutoff_hz_arr[i])
-        fc = 20.0 if fc < 20.0 else (sr/2 - 200.0 if fc > (sr/2 - 200.0) else fc)
-        alpha = (twopi * fc) / (twopi * fc + sr)
-        z += alpha * (x[i] - z); y[i] = z
-    return y
-
-def one_pole_hp(x, cutoff_hz, sr):
-    c = np.full_like(x, float(cutoff_hz), dtype=np.float32)
-    return x - one_pole_lp(x, c, sr)
-
-def soft_clip_tanh(x, drive=2.5):
-    return np.tanh(x * drive).astype(np.float32) / np.tanh(float(drive))
-
-# ------------------------------ oscillators -----------------------------------
-def osc_saw(freq_arr, sr):
-    # Phase-integrated saw with simple wrap (aliased but light/fast)
-    phase = np.cumsum(2*np.pi*freq_arr/sr, dtype=np.float32)
-    saw = 2.0*(phase/(2*np.pi) - np.floor(0.5 + phase/(2*np.pi)))
-    return saw.astype(np.float32)
-
-def osc_square(freq_arr, sr):
-    phase = np.cumsum(2*np.pi*freq_arr/sr, dtype=np.float32)
-    return np.sign(np.sin(phase)).astype(np.float32)
-
-def osc_sine(freq_arr, sr):
-    phase = np.cumsum(2*np.pi*freq_arr/sr, dtype=np.float32)
-    return np.sin(phase).astype(np.float32)
-
-# ------------------------------ envelopes -------------------------------------
-def adsr(n_on, sr, a=0.005, d=0.12, s=0.65, r=0.25):
-    """ADSR safe for very short notes (n_on can be < a+d). Release starts at note-off."""
-    a_n = max(1, int(round(a*sr)))
-    d_n = max(1, int(round(d*sr)))
-    r_n = max(1, int(round(r*sr)))
-
-    env = np.zeros(n_on + r_n, dtype=np.float32)
-
-    # Attack (partial if needed)
-    nA = min(a_n, n_on)
-    if nA > 0:
-        env[:nA] = np.linspace(0.0, 1.0, nA, endpoint=False, dtype=np.float32)
-    pos = nA
-
-    # Decay (partial if needed)
-    if pos < n_on:
-        nD = min(d_n, n_on - pos)
-        if nD > 0:
-            decay_full = np.linspace(1.0, s, d_n, endpoint=False, dtype=np.float32)
-            env[pos:pos+nD] = decay_full[:nD]
-            pos += nD
-
-    # Sustain
-    if pos < n_on:
-        env[pos:n_on] = s
-        pos = n_on
-
-    # Release from current level
-    rel_level = float(env[n_on - 1]) if n_on > 0 else 0.0
-    env[n_on:n_on + r_n] = np.linspace(rel_level, 0.0, r_n, endpoint=False, dtype=np.float32)
-    return env
-
-# ------------------------------ instruments -----------------------------------
-def synth_tone(freq, dur, sr, *,
-               osc='saw', detune_cents=6.0,
-               cutoff_start=7000.0, cutoff_end=2200.0,
-               a=0.005, d=0.12, s=0.65, r=0.25,
-               vibrato_hz=0.0, vibrato_cents=0.0,
-               drive=0.0, amp=0.5):
-    """Detuned dual-osc -> LP sweep -> ADSR -> optional drive. Returns mono float32."""
-    n_on = int(max(1, round(dur*sr)))
-    env = adsr(n_on, sr, a=a, d=d, s=s, r=r)
-    n_total = len(env)
-    t = np.arange(n_total, dtype=np.float32)/sr
-
-    # Vibrato
-    if vibrato_hz > 0.0 and vibrato_cents > 0.0:
-        vib = np.sin(2*np.pi*vibrato_hz*t).astype(np.float32) * float(vibrato_cents)
-        vib_fac = (2.0 ** (vib/1200.0)).astype(np.float32)
-    else:
-        vib_fac = 1.0
-
-    det = 2.0 ** (detune_cents/1200.0)
-    f1 = np.full(n_total, float(freq), dtype=np.float32)
-    f2 = np.full(n_total, float(freq*det), dtype=np.float32)
-    if isinstance(vib_fac, np.ndarray):
-        f1 *= vib_fac; f2 *= vib_fac
-
-    if osc == 'square':
-        x1 = osc_square(f1, sr); x2 = osc_square(f2, sr)
-    elif osc == 'sine':
-        x1 = osc_sine(f1, sr);   x2 = osc_sine(f2, sr)
-    else:
-        x1 = osc_saw(f1, sr);    x2 = osc_saw(f2, sr)
-
-    raw = (0.6*x1 + 0.4*x2).astype(np.float32)
-
-    # LP sweep
-    c_env = np.linspace(float(cutoff_start), float(cutoff_end), n_total, dtype=np.float32)
-    y = one_pole_lp(raw, c_env, sr)
-
-    # Drive
-    if drive and drive > 0.0:
-        y = soft_clip_tanh(y, drive=drive)
-
-    out = (y * env * float(amp)).astype(np.float32)
-    return out
-
-def synth_bass_note(freq, dur, sr, amp=0.35):
-    """Detuned square -> LP ~400 Hz, short decay."""
-    n = int(max(1, dur*sr)); t = np.arange(n, dtype=np.float32)/sr
-    sq1 = np.sign(np.sin(2*np.pi*freq*t)).astype(np.float32)
-    sq2 = np.sign(np.sin(2*np.pi*freq*1.01*t)).astype(np.float32)
-    x = 0.6*sq1 + 0.4*sq2
-    env = np.exp(-t*6.0).astype(np.float32)
-    x = x * env
-    cutoff = np.full(n, 400.0, dtype=np.float32)
-    y = one_pole_lp(x, cutoff, sr)
-    return (y * float(amp)).astype(np.float32)
-
-# ---- Drums ----
-def synth_kick(sr, dur=0.22, amp=0.9):
-    n = int(max(1, dur*sr)); t = np.arange(n, dtype=np.float32)/sr
-    f_start, f_end, k = 120.0, 45.0, 20.0
-    f = f_end + (f_start - f_end) * np.exp(-k*t)
-    phase = np.cumsum(2*np.pi*f/sr, dtype=np.float32)
-    body = np.sin(phase).astype(np.float32)
-    env = np.exp(-t*28.0).astype(np.float32)
-    click = (np.exp(-t*2000.0)*0.5).astype(np.float32)
-    sig = body*env + click
-    return (sig * float(amp)).astype(np.float32)
-
-def synth_snare(sr, dur=0.18, amp=0.4):
-    n = int(max(1, dur*sr)); t = np.arange(n, dtype=np.float32)/sr
-    noise = (np.random.rand(n).astype(np.float32)*2.0 - 1.0)
-    noise = one_pole_hp(noise, 1800.0, sr)
-    tone = np.sin(2*np.pi*190.0*t).astype(np.float32) * np.exp(-t*30.0)
-    env = np.exp(-t*40.0).astype(np.float32)
-    sig = 0.85*noise*env + 0.15*tone
-    return (sig * float(amp)).astype(np.float32)
-
-def synth_hat(sr, dur=0.06, amp=0.22, open_=False):
-    n = int(max(1, dur*sr)); t = np.arange(n, dtype=np.float32)/sr
-    noise = (np.random.rand(n).astype(np.float32)*2.0 - 1.0)
-    noise = one_pole_hp(noise, 6500.0, sr)
-    decay = 50.0 if open_ else 120.0
-    env = np.exp(-t*decay).astype(np.float32)
-    sig = noise * env
-    return (sig * float(amp)).astype(np.float32)
-
-def synth_tom(sr, base_hz=120.0, dur=0.25, amp=0.45):
-    n = int(max(1, dur*sr)); t = np.arange(n, dtype=np.float32)/sr
-    f = base_hz + 10*np.exp(-15.0*t)
-    phase = np.cumsum(2*np.pi*f/sr, dtype=np.float32)
-    tone = np.sin(phase).astype(np.float32)
-    tone *= np.exp(-t*12.0).astype(np.float32)
-    attack = (np.random.rand(n).astype(np.float32)*2.0 - 1.0)
-    attack = one_pole_hp(attack, 3000.0, sr) * np.exp(-t*200.0).astype(np.float32) * 0.2
-    return ((tone + attack) * float(amp)).astype(np.float32)
-
-def synth_crash(sr, dur=1.8, amp=0.25):
-    n = int(max(1, dur*sr)); t = np.arange(n, dtype=np.float32)/sr
-    noise = (np.random.rand(n).astype(np.float32)*2.0 - 1.0)
-    noise = one_pole_hp(noise, 4000.0, sr)
-    env = np.exp(-t*2.2).astype(np.float32)
-    sig = noise * env
-    return (sig * float(amp)).astype(np.float32)
-
-# ------------------------------- mixing utils --------------------------------
-def mix_mono(stereo, start, sig, pan=0.0):
-    """Mix mono into stereo buffer at 'start' with simple pan; clamps to buffer (no extension)."""
-    if start >= stereo.shape[1]:
-        return stereo
-    pan = float(max(-1.0, min(1.0, pan)))
-    lg = 0.5*(1.0 - pan); rg = 0.5*(1.0 + pan)
-    end = min(start + len(sig), stereo.shape[1])
-    seg = sig[:max(0, end - start)]
-    stereo[0, start:end] += seg * lg
-    stereo[1, start:end] += seg * rg
-    return stereo
-
-def stereo_cross_delay_offline(stereo, sr, delay_s=0.24, mix=0.18):
-    d = max(1,int(delay_s*sr)); out = stereo.copy()
-    if d < out.shape[1]:
-        out[0, d:] += mix*stereo[1, :-d]; out[1, d:] += mix*stereo[0, :-d]
-    return out
-
-class CrossDelayState:
-    """Streaming version of the cross-delay that exactly matches the offline effect."""
-    def __init__(self, sr, delay_s=0.24, mix=0.18):
-        self.d = max(0, int(round(delay_s*sr)))
-        self.mix = float(mix)
-        self.rL = np.zeros(self.d, dtype=np.float32) if self.d > 0 else None
-        self.rR = np.zeros(self.d, dtype=np.float32) if self.d > 0 else None
-
-    def apply(self, dryL, dryR):
-        if self.d == 0:
-            return dryL.copy(), dryR.copy()
-        n = dryL.shape[0]
-        wetL = dryL.copy()
-        wetR = dryR.copy()
-
-        # Cross from R->L and L->R
-        k = min(self.d, n)
-        # Begin of chunk: pull from ring (previous chunk history)
-        wetL[:k] += self.mix * self.rR[:k]
-        wetR[:k] += self.mix * self.rL[:k]
-        # Remainder of chunk: cross-feed inside the same chunk
         if n > self.d:
             wetL[self.d:] += self.mix * dryR[:n - self.d]
             wetR[self.d:] += self.mix * dryL[:n - self.d]
@@ -348,56 +141,6 @@ def play_with_pyaudio(stereo, sr, frames_per_buffer=2048, device_index=None, dev
             p.terminate()
 
 # ----------------------------- GM instrument map -----------------------------
-def program_to_inst(prog):
-    """Return a compact instrument 'tag' based on GM program (0..127)."""
-    p = int(prog)
-    if p in (29, 30):            # Overdriven/Distortion Guitar
-        return 'dist_gtr'
-    if 24 <= p <= 31:            # Guitars
-        return 'clean_gtr'
-    if 32 <= p <= 39:            # Basses
-        return 'bass'
-    if 40 <= p <= 51:            # Solo strings + ensemble
-        return 'strings'
-    if 80 <= p <= 87:            # Leads (square/saw)
-        return 'lead'
-    if p == 56:                  # Harp
-        return 'pluck'
-    return 'piano'               # default
-
-def inst_params(tag, vel=100):
-    """Map instrument tag to synth parameters (coarse but musical)."""
-    v = max(1, min(127, int(vel)))
-    vsc = (v/127.0) ** 1.4  # perceptual-ish velocity curve
-    if tag == 'piano':
-        return dict(osc='saw', detune_cents=5.0,
-                    cutoff_start=5200.0, cutoff_end=900.0,
-                    a=0.003, d=0.22, s=0.55, r=0.6, drive=0.0, amp=0.55*vsc)
-    if tag == 'clean_gtr':
-        return dict(osc='square', detune_cents=4.0,
-                    cutoff_start=6000.0, cutoff_end=1800.0,
-                    a=0.004, d=0.12, s=0.60, r=0.35, drive=0.0, amp=0.5*vsc)
-    if tag == 'dist_gtr':
-        return dict(osc='saw', detune_cents=6.0,
-                    cutoff_start=7000.0, cutoff_end=2200.0,
-                    a=0.004, d=0.10, s=0.70, r=0.42, drive=3.2, amp=0.48*vsc)
-    if tag == 'strings':
-        return dict(osc='saw', detune_cents=9.0,
-                    cutoff_start=7500.0, cutoff_end=2500.0,
-                    a=0.045, d=0.40, s=0.90, r=1.6, drive=0.0, amp=0.42*vsc)
-    if tag == 'lead':
-        return dict(osc='saw', detune_cents=3.0,
-                    cutoff_start=6800.0, cutoff_end=1700.0,
-                    a=0.006, d=0.10, s=0.65, r=0.45, drive=1.0, amp=0.5*vsc)
-    if tag == 'pluck':
-        return dict(osc='saw', detune_cents=4.0,
-                    cutoff_start=5400.0, cutoff_end=1200.0,
-                    a=0.002, d=0.18, s=0.40, r=0.25, drive=0.0, amp=0.5*vsc)
-    # fallback
-    return dict(osc='saw', detune_cents=6.0,
-                cutoff_start=6500.0, cutoff_end=2000.0,
-                a=0.005, d=0.12, s=0.65, r=0.35, drive=0.0, amp=0.5*vsc)
-
 # ----------------------------- MIDI -> note events (Option A) -----------------
 class NoteEvent:
     __slots__ = ("start","end","note","vel","chan","program","pan","vol","is_drum")
@@ -943,26 +686,9 @@ class RealtimePlayer:
                 p.terminate()
 
 # ----------------------------------- main ------------------------------------
-def main():
-    ap = argparse.ArgumentParser(description="32‑voice MIDI softsynth with PyAudio playback (quiet).")
-    ap.add_argument("--midi", help="Path to a legally obtained MIDI file to render.")
-    ap.add_argument("--frames", type=int, default=2048, help="Frames per buffer for streaming (PyAudio).")
-    ap.add_argument("--device-index", type=int, default=None, help="PyAudio output device index.")
-    ap.add_argument("--device-name", type=str, default=None, help="Substring to select device (e.g., 'pulse').")
-    ap.add_argument("--poly", type=int, default=32, help="Max pitched voices per 20ms window (drums excluded).")
-    ap.add_argument("--gain", type=float, default=0.90, help="Master gain multiplier after normalization.")
-    ap.add_argument("--save", action="store_true", help="Also save rendered WAV (midi_synth32.wav).")
-    ap.add_argument("--progress", action="store_true", help="Show progress on stderr.")
-    ap.add_argument("--preview", type=float, default=0.0, help="Render only the first N seconds (0 = full song).")
-    ap.add_argument("--test-tone", action="store_true", help="Play a 2s test tone instead of MIDI.")
-    ap.add_argument("--tail", type=float, default=2.0, help="Extra seconds after the last musical event.")
-    ap.add_argument("--max-note-dur", type=float, default=30.0, help="Clamp any single note duration (0 disables).")
-    # New realtime options
-    ap.add_argument("--realtime", action="store_true", help="Play in realtime with prebuffered chunks (no DSP simplifications).")
-    ap.add_argument("--prebuffer", type=float, default=3.0, help="Seconds of audio to prebuffer/look-ahead in realtime mode.")
-    args = ap.parse_args()
 
-    # Print ONLY the device list (stdout) immediately (even before MIDI) so you see life.
+def run(args):
+    """Execute playback or rendering based on parsed arguments."""
     with capture_stderr():
         pa = pyaudio.PyAudio()
         try:
@@ -972,24 +698,25 @@ def main():
     for line in dev_lines:
         print(line)
 
-    if args.test_tone:
+    if getattr(args, 'test_tone', False):
         buf = render_test_tone(sr=SR, dur=2.0, hz=440.0)
-        err = play_with_pyaudio(buf, SR, frames_per_buffer=args.frames,
-                                device_index=args.device_index, device_name=args.device_name)
+        err = play_with_pyaudio(
+            buf, SR, frames_per_buffer=args.frames,
+            device_index=args.device_index, device_name=args.device_name
+        )
         if err:
-            sys.stderr.write(err); sys.exit(1)
+            sys.stderr.write(err)
+            sys.exit(1)
         return
 
     if not args.midi:
         sys.stderr.write("error: --midi is required unless --test-tone is used\n")
         sys.exit(2)
 
-    # Parse MIDI with same-tick NOTE-ON-before-NOTE-OFF policy (Option A)
     events, music_end = parse_midi_to_events(args.midi)
 
-    if args.realtime:
-        # Realtime path: render chunk-by-chunk at full quality with prebuffer look-ahead
-        cap_end = music_end  # full musical end
+    if getattr(args, 'realtime', False):
+        cap_end = music_end
         prer = RealtimePreRenderer(
             events, SR, frames_per_buffer=args.frames,
             cap_end_s=cap_end, tail_s=float(args.tail),
@@ -1003,10 +730,10 @@ def main():
         )
         err = player.play()
         if err:
-            sys.stderr.write(err); sys.exit(1)
+            sys.stderr.write(err)
+            sys.exit(1)
         return
 
-    # Offline render path (previous behavior)
     t_prev = args.preview if args.preview and args.preview > 0.0 else 0.0
     events_to_render = limit_events_to_preview(events, t_prev) if t_prev > 0.0 else events
     cap_end = min(music_end, t_prev) if t_prev > 0.0 else music_end
@@ -1022,9 +749,10 @@ def main():
         max_note_dur_s=(float(args.max_note_dur) if float(args.max_note_dur) > 0.0 else 0.0)
     )
 
-    # Play; on error, print captured stderr + exception
-    err = play_with_pyaudio(buf, SR, frames_per_buffer=args.frames,
-                            device_index=args.device_index, device_name=args.device_name)
+    err = play_with_pyaudio(
+        buf, SR, frames_per_buffer=args.frames,
+        device_index=args.device_index, device_name=args.device_name
+    )
     if err:
         sys.stderr.write(err)
         sys.exit(1)
@@ -1032,5 +760,3 @@ def main():
     if args.save:
         write_wav_stereo("midi_synth32.wav", buf, SR)
 
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## Summary
- split monolithic MIDI renderer into modular `midiplayer` package
- expose a `midi_player.py` entrypoint and CLI parser
- document softsynth usage in README

## Testing
- `python -m py_compile midi_player.py midiplayer/*.py`
- `pip install numpy mido pyaudio` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9970d23c832588d77b41861289fa