### PR TITLE
Add C DCT finetune encoder and decoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+soundtest/

--- a/c/Makefile
+++ b/c/Makefile
@@ -1,0 +1,17 @@
+.RECIPEPREFIX = >
+
+CC=gcc
+CFLAGS=-O2 -std=c11 -Wall -Wextra
+
+all: encoder decoder
+
+encoder: encoder.o dct.o entropy.o wav.o
+>$(CC) $(CFLAGS) -o encoder encoder.o dct.o entropy.o wav.o -lm
+
+decoder: decoder.o dct.o wav.o
+>$(CC) $(CFLAGS) -o decoder decoder.o dct.o wav.o -lm
+
+clean:
+>rm -f encoder decoder *.o
+
+.PHONY: all clean

--- a/c/README.md
+++ b/c/README.md
@@ -1,0 +1,103 @@
+# C Implementation of 8-bit DCT Finetune Encoder/Decoder
+
+This directory contains a pure C reimplementation of the Python tools
+`03-encoder-8bit-dct-finetune.py` and `03-decoder-8bit-dct-finetune.py`.
+The goal is to provide a standalone project that can be built with a
+simple `make` command and run without any Python dependencies.
+
+## Features
+
+* Processes stereo WAV files (44.1 kHz, 16-bit PCM).
+* Encodes audio in blocks of 4096 samples per channel using a
+  Discrete Cosine Transform (DCT-II) with orthonormal scaling.
+* Searches for an 8-bit quantization level that matches a target
+  Shannon entropy.
+* Decoder reconstructs audio using the inverse DCT and writes the
+  result to a WAV file while applying a small ramp to reduce block
+  discontinuities.
+* Data is transferred between encoder and decoder through a UNIX
+  named pipe (`audiofifo1.fifo`) in the same format as the original
+  Python scripts.
+
+## Project Layout
+
+```
+Makefile       – build rules for `encoder` and `decoder`
+dct.c/.h       – orthonormal DCT-II and inverse DCT implementations
+entropy.c/.h   – entropy calculation helpers
+wav.c/.h       – minimal WAV reader/writer for 16-bit PCM
+encoder.c      – command line encoder
+decoder.c      – command line decoder
+```
+
+## Building
+
+This project uses only the C standard library and `gcc`. On Ubuntu
+install the build tools with:
+
+```bash
+sudo apt-get install build-essential
+```
+
+Compile the project:
+
+```bash
+cd c
+make
+```
+
+This produces two executables: `encoder` and `decoder`.
+
+## Running
+
+1. **Prepare a FIFO**
+
+   ```bash
+   mkfifo audiofifo1.fifo
+   ```
+
+2. **Run the encoder**
+
+   ```bash
+   ./encoder input.wav 2.0
+   ```
+
+   The encoder reads `input.wav`, searches for a quantization level
+   that achieves the target entropy (2.0 bits per byte by default) and
+   writes encoded blocks to `audiofifo1.fifo`.
+
+3. **Run the decoder**
+
+   In another terminal start the decoder which reads from the FIFO and
+   writes a reconstructed WAV file (`debug.wav` by default):
+
+   ```bash
+   ./decoder output.wav
+   ```
+
+   After the encoder finishes, the decoded audio will be available in
+   `output.wav`.
+
+4. **Play the result**
+
+   You can listen to the output using any WAV player, e.g. `aplay`:
+
+   ```bash
+   aplay output.wav
+   ```
+
+## Notes
+
+* The DCT and entropy calculations are implemented directly in C to
+  avoid external dependencies. While this is sufficient for small
+  experiments, it is slower than optimized libraries such as FFTW.
+* The implementation mirrors the structure of the original Python
+  scripts but omits real-time audio playback. The decoder instead
+  writes the reconstructed signal to a WAV file.
+* Block size and other parameters can be adjusted in the source code
+  if desired.
+
+## License
+
+This code is provided under the same license as the rest of the
+repository. See `../LICENSE` for details.

--- a/c/dct.c
+++ b/c/dct.c
@@ -1,0 +1,28 @@
+#include "dct.h"
+#include <math.h>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+void dct_ii(const double *in, double *out, size_t n) {
+    double factor = sqrt(2.0 / n);
+    for (size_t k = 0; k < n; ++k) {
+        double sum = 0.0;
+        for (size_t i = 0; i < n; ++i) {
+            sum += in[i] * cos(M_PI / n * (i + 0.5) * k);
+        }
+        out[k] = factor * sum;
+    }
+    out[0] /= sqrt(2.0);
+}
+
+void idct_ii(const double *in, double *out, size_t n) {
+    double factor = sqrt(2.0 / n);
+    for (size_t i = 0; i < n; ++i) {
+        double sum = in[0] / sqrt(2.0);
+        for (size_t k = 1; k < n; ++k) {
+            sum += in[k] * cos(M_PI / n * (i + 0.5) * k);
+        }
+        out[i] = factor * sum;
+    }
+}

--- a/c/dct.h
+++ b/c/dct.h
@@ -1,0 +1,9 @@
+#ifndef DCT_H
+#define DCT_H
+
+#include <stddef.h>
+
+void dct_ii(const double *in, double *out, size_t n);
+void idct_ii(const double *in, double *out, size_t n);
+
+#endif // DCT_H

--- a/c/decoder.c
+++ b/c/decoder.c
@@ -1,0 +1,88 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include "dct.h"
+#include "wav.h"
+
+#define BLOCK_SIZE 4096
+#define CHANNELS 2
+
+int main(int argc, char *argv[]) {
+    const char *fifo_path = "audiofifo1.fifo";
+    const char *output_wav = (argc > 1) ? argv[1] : "debug.wav";
+
+    FILE *fifo = fopen(fifo_path, "rb");
+    if (!fifo) { perror("open fifo"); return 1; }
+
+    FILE *out = open_wav_write(output_wav, 44100, 2, 16);
+    if (!out) { perror("open output wav"); fclose(fifo); return 1; }
+
+    double dct_coeffs[CHANNELS][BLOCK_SIZE];
+    double samples[CHANNELS][BLOCK_SIZE];
+    int16_t output_buffer[BLOCK_SIZE * CHANNELS];
+    double last_left = 0.0, last_right = 0.0;
+    int data_written = 0;
+
+    while (1) {
+        int max_value = fgetc(fifo);
+        if (max_value == EOF) break;
+        double max_coeff;
+        if (fread(&max_coeff, sizeof(double), 1, fifo) != 1) break;
+        int8_t quantized[BLOCK_SIZE * CHANNELS];
+        if (fread(quantized, 1, BLOCK_SIZE * CHANNELS, fifo) != BLOCK_SIZE * CHANNELS) break;
+
+        for (size_t i = 0; i < BLOCK_SIZE; ++i) {
+            for (int ch = 0; ch < CHANNELS; ++ch) {
+                double norm = (double)quantized[i * CHANNELS + ch] / (double)max_value;
+                dct_coeffs[ch][i] = norm * max_coeff;
+            }
+        }
+
+        idct_ii(dct_coeffs[0], samples[0], BLOCK_SIZE);
+        idct_ii(dct_coeffs[1], samples[1], BLOCK_SIZE);
+
+        double max_abs = 0.0;
+        for (int ch = 0; ch < CHANNELS; ++ch) {
+            for (size_t i = 0; i < BLOCK_SIZE; ++i) {
+                if (fabs(samples[ch][i]) > max_abs) max_abs = fabs(samples[ch][i]);
+            }
+        }
+        if (max_abs > 32767.0) {
+            double scale = 32767.0 / max_abs;
+            for (int ch = 0; ch < CHANNELS; ++ch)
+                for (size_t i = 0; i < BLOCK_SIZE; ++i)
+                    samples[ch][i] *= scale;
+        }
+        for (int ch = 0; ch < CHANNELS; ++ch)
+            for (size_t i = 0; i < BLOCK_SIZE; ++i)
+                samples[ch][i] *= 0.95;
+
+        int ramp_length = (int)(0.2 * BLOCK_SIZE);
+        if (ramp_length > 0) {
+            for (int i = 0; i < ramp_length; ++i) {
+                double t = (double)i / ramp_length;
+                double left_ramp = last_left + (samples[0][0] - last_left) * t;
+                double right_ramp = last_right + (samples[1][0] - last_right) * t;
+                samples[0][i] = left_ramp + samples[0][i] - samples[0][0];
+                samples[1][i] = right_ramp + samples[1][i] - samples[1][0];
+            }
+        }
+        last_left = samples[0][BLOCK_SIZE - 1];
+        last_right = samples[1][BLOCK_SIZE - 1];
+
+        for (size_t i = 0; i < BLOCK_SIZE; ++i) {
+            int16_t l = (int16_t)lrint(samples[0][i]);
+            int16_t r = (int16_t)lrint(samples[1][i]);
+            output_buffer[2 * i] = l;
+            output_buffer[2 * i + 1] = r;
+        }
+        fwrite(output_buffer, sizeof(int16_t) * CHANNELS, BLOCK_SIZE, out);
+        data_written += BLOCK_SIZE * CHANNELS * sizeof(int16_t);
+    }
+
+    close_wav_write(out, 44100, 2, 16, data_written);
+    fclose(fifo);
+    return 0;
+}

--- a/c/encoder.c
+++ b/c/encoder.c
@@ -1,0 +1,101 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include "dct.h"
+#include "entropy.h"
+#include "wav.h"
+
+#define BLOCK_SIZE 4096
+#define CHANNELS 2
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <input_wav_file> [target_entropy]\n", argv[0]);
+        return 1;
+    }
+    const char *input_wav_file = argv[1];
+    double target_entropy = (argc > 2) ? atof(argv[2]) : 2.0;
+    const char *fifo_path = "audiofifo1.fifo";
+
+    FILE *wav = fopen(input_wav_file, "rb");
+    if (!wav) { perror("open input wav"); return 1; }
+    int sample_rate, channels, bits_per_sample, data_size;
+    if (read_wav_header(wav, &sample_rate, &channels, &bits_per_sample, &data_size) != 0 ||
+        sample_rate != 44100 || channels != 2 || bits_per_sample != 16) {
+        fprintf(stderr, "Input file must be 44100 Hz, stereo, 16-bit PCM.\n");
+        fclose(wav);
+        return 1;
+    }
+
+    FILE *fifo = fopen(fifo_path, "wb");
+    if (!fifo) { perror("open fifo"); fclose(wav); return 1; }
+
+    int16_t buffer[BLOCK_SIZE * CHANNELS];
+    double chan[CHANNELS][BLOCK_SIZE];
+    double dct_coeffs[CHANNELS][BLOCK_SIZE];
+    int8_t best_quantized[BLOCK_SIZE * CHANNELS];
+    int8_t temp_quantized[BLOCK_SIZE * CHANNELS];
+
+    while (1) {
+        size_t read = fread(buffer, sizeof(int16_t) * CHANNELS, BLOCK_SIZE, wav);
+        if (read == 0) break;
+        for (size_t i = 0; i < read; ++i) {
+            chan[0][i] = buffer[2 * i];
+            chan[1][i] = buffer[2 * i + 1];
+        }
+        if (read < BLOCK_SIZE) {
+            for (size_t i = read; i < BLOCK_SIZE; ++i) {
+                chan[0][i] = 0;
+                chan[1][i] = 0;
+            }
+        }
+
+        dct_ii(chan[0], dct_coeffs[0], BLOCK_SIZE);
+        dct_ii(chan[1], dct_coeffs[1], BLOCK_SIZE);
+
+        double closest = 1e9;
+        int best_max_value = 1;
+        double best_max_coeff = 0;
+        for (int max_value = 1; max_value <= 255; max_value += 4) {
+            double max_coeff = fabs(dct_coeffs[0][0]);
+            for (int ch = 0; ch < CHANNELS; ++ch) {
+                for (size_t i = 0; i < BLOCK_SIZE; ++i) {
+                    double val = fabs(dct_coeffs[ch][i]);
+                    if (val > max_coeff) max_coeff = val;
+                }
+            }
+            if (max_coeff == 0) max_coeff = 1;
+            for (int ch = 0; ch < CHANNELS; ++ch) {
+                for (size_t i = 0; i < BLOCK_SIZE; ++i) {
+                    double norm = dct_coeffs[ch][i] / max_coeff;
+                    int8_t q = (int8_t)(norm * max_value);
+                    temp_quantized[i * CHANNELS + ch] = q;
+                }
+            }
+            double ent = calculate_byte_entropy(temp_quantized, BLOCK_SIZE * CHANNELS);
+            double diff = fabs(ent - target_entropy);
+            if (diff < closest) {
+                closest = diff;
+                best_max_value = max_value;
+                best_max_coeff = max_coeff;
+                memcpy(best_quantized, temp_quantized, BLOCK_SIZE * CHANNELS);
+            }
+        }
+
+        fprintf(stdout, "Selected max value: %d, Achieved Entropy: %.2f\n",
+                best_max_value, calculate_byte_entropy(best_quantized, BLOCK_SIZE * CHANNELS));
+        double in_entropy = calculate_16bit_entropy(buffer, read * CHANNELS);
+        double out_entropy = calculate_byte_entropy(best_quantized, BLOCK_SIZE * CHANNELS);
+        fprintf(stdout, "InEntropy: %.2f bits  OutEntropy: %.2f bits\n", in_entropy, out_entropy);
+
+        fputc(best_max_value, fifo);
+        fwrite(&best_max_coeff, sizeof(double), 1, fifo);
+        fwrite(best_quantized, 1, BLOCK_SIZE * CHANNELS, fifo);
+    }
+
+    fclose(fifo);
+    fclose(wav);
+    return 0;
+}

--- a/c/entropy.c
+++ b/c/entropy.c
@@ -1,0 +1,38 @@
+#include "entropy.h"
+#include <math.h>
+
+#define BYTE_VALUES 256
+
+double calculate_byte_entropy(const int8_t *data, size_t length) {
+    if (length == 0) return 0.0;
+    unsigned int counts[BYTE_VALUES] = {0};
+    for (size_t i = 0; i < length; ++i) {
+        unsigned char b = (unsigned char)data[i];
+        counts[b]++;
+    }
+    double entropy = 0.0;
+    for (int i = 0; i < BYTE_VALUES; ++i) {
+        if (counts[i] != 0) {
+            double p = (double)counts[i] / (double)length;
+            entropy -= p * (log(p) / log(2.0));
+        }
+    }
+    return entropy;
+}
+
+double calculate_16bit_entropy(const int16_t *data, size_t length) {
+    if (length == 0) return 0.0;
+    unsigned int counts[65536] = {0};
+    for (size_t i = 0; i < length; ++i) {
+        unsigned short v = (unsigned short)(data[i] + 32768);
+        counts[v]++;
+    }
+    double entropy = 0.0;
+    for (int i = 0; i < 65536; ++i) {
+        if (counts[i] != 0) {
+            double p = (double)counts[i] / (double)length;
+            entropy -= p * (log(p) / log(2.0));
+        }
+    }
+    return entropy;
+}

--- a/c/entropy.h
+++ b/c/entropy.h
@@ -1,0 +1,10 @@
+#ifndef ENTROPY_H
+#define ENTROPY_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+double calculate_byte_entropy(const int8_t *data, size_t length);
+double calculate_16bit_entropy(const int16_t *data, size_t length);
+
+#endif // ENTROPY_H

--- a/c/wav.c
+++ b/c/wav.c
@@ -1,0 +1,101 @@
+#include "wav.h"
+#include <string.h>
+
+int read_wav_header(FILE *f, int *sample_rate, int *channels, int *bits_per_sample, int *data_size) {
+    unsigned char header[44];
+    if (fread(header, 1, 44, f) != 44) return -1;
+    if (memcmp(header, "RIFF", 4) != 0) return -1;
+    if (memcmp(header + 8, "WAVE", 4) != 0) return -1;
+    if (memcmp(header + 12, "fmt ", 4) != 0) return -1;
+    int fmt_size = header[16] | (header[17] << 8) | (header[18] << 16) | (header[19] << 24);
+    if (fmt_size < 16) return -1;
+    int audio_format = header[20] | (header[21] << 8);
+    *channels = header[22] | (header[23] << 8);
+    *sample_rate = header[24] | (header[25] << 8) | (header[26] << 16) | (header[27] << 24);
+    *bits_per_sample = header[34] | (header[35] << 8);
+    if (audio_format != 1) return -1; // PCM only
+    // Find 'data' chunk
+    long pos = 12 + 8 + fmt_size;
+    fseek(f, pos, SEEK_SET);
+    while (1) {
+        unsigned char chunk[8];
+        if (fread(chunk, 1, 8, f) != 8) return -1;
+        int size = chunk[4] | (chunk[5] << 8) | (chunk[6] << 16) | (chunk[7] << 24);
+        if (memcmp(chunk, "data", 4) == 0) {
+            *data_size = size;
+            return 0;
+        }
+        fseek(f, size, SEEK_CUR);
+    }
+}
+
+FILE *open_wav_write(const char *filename, int sample_rate, int channels, int bits_per_sample) {
+    FILE *f = fopen(filename, "wb");
+    if (!f) return NULL;
+    unsigned char header[44] = {0};
+    memcpy(header, "RIFF", 4);
+    memcpy(header + 8, "WAVE", 4);
+    memcpy(header + 12, "fmt ", 4);
+    int fmt_size = 16;
+    header[16] = fmt_size & 0xFF;
+    header[17] = (fmt_size >> 8) & 0xFF;
+    header[18] = (fmt_size >> 16) & 0xFF;
+    header[19] = (fmt_size >> 24) & 0xFF;
+    header[20] = 1; // PCM
+    header[22] = channels & 0xFF;
+    header[23] = (channels >> 8) & 0xFF;
+    header[24] = sample_rate & 0xFF;
+    header[25] = (sample_rate >> 8) & 0xFF;
+    header[26] = (sample_rate >> 16) & 0xFF;
+    header[27] = (sample_rate >> 24) & 0xFF;
+    int byte_rate = sample_rate * channels * bits_per_sample / 8;
+    header[28] = byte_rate & 0xFF;
+    header[29] = (byte_rate >> 8) & 0xFF;
+    header[30] = (byte_rate >> 16) & 0xFF;
+    header[31] = (byte_rate >> 24) & 0xFF;
+    int block_align = channels * bits_per_sample / 8;
+    header[32] = block_align & 0xFF;
+    header[33] = (block_align >> 8) & 0xFF;
+    header[34] = bits_per_sample & 0xFF;
+    header[35] = (bits_per_sample >> 8) & 0xFF;
+    memcpy(header + 36, "data", 4);
+    fwrite(header, 1, 44, f);
+    return f;
+}
+
+void close_wav_write(FILE *f, int sample_rate, int channels, int bits_per_sample, int data_size) {
+    int file_size = 36 + data_size;
+    int byte_rate = sample_rate * channels * bits_per_sample / 8;
+    int block_align = channels * bits_per_sample / 8;
+    unsigned char header[44];
+    fseek(f, 0, SEEK_SET);
+    memcpy(header, "RIFF", 4);
+    header[4] = file_size & 0xFF;
+    header[5] = (file_size >> 8) & 0xFF;
+    header[6] = (file_size >> 16) & 0xFF;
+    header[7] = (file_size >> 24) & 0xFF;
+    memcpy(header + 8, "WAVE", 4);
+    memcpy(header + 12, "fmt ", 4);
+    header[16] = 16; header[17]=0; header[18]=0; header[19]=0;
+    header[20] = 1; header[21] = 0;
+    header[22] = channels & 0xFF; header[23] = (channels >> 8) & 0xFF;
+    header[24] = sample_rate & 0xFF;
+    header[25] = (sample_rate >> 8) & 0xFF;
+    header[26] = (sample_rate >> 16) & 0xFF;
+    header[27] = (sample_rate >> 24) & 0xFF;
+    header[28] = byte_rate & 0xFF;
+    header[29] = (byte_rate >> 8) & 0xFF;
+    header[30] = (byte_rate >> 16) & 0xFF;
+    header[31] = (byte_rate >> 24) & 0xFF;
+    header[32] = block_align & 0xFF;
+    header[33] = (block_align >> 8) & 0xFF;
+    header[34] = bits_per_sample & 0xFF;
+    header[35] = (bits_per_sample >> 8) & 0xFF;
+    memcpy(header + 36, "data", 4);
+    header[40] = data_size & 0xFF;
+    header[41] = (data_size >> 8) & 0xFF;
+    header[42] = (data_size >> 16) & 0xFF;
+    header[43] = (data_size >> 24) & 0xFF;
+    fwrite(header, 1, 44, f);
+    fclose(f);
+}

--- a/c/wav.h
+++ b/c/wav.h
@@ -1,0 +1,12 @@
+#ifndef WAV_H
+#define WAV_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+
+int read_wav_header(FILE *f, int *sample_rate, int *channels, int *bits_per_sample, int *data_size);
+FILE *open_wav_write(const char *filename, int sample_rate, int channels, int bits_per_sample);
+void close_wav_write(FILE *f, int sample_rate, int channels, int bits_per_sample, int data_size);
+
+#endif // WAV_H


### PR DESCRIPTION
## Summary
- Provide pure C versions of DCT-based 8-bit encoder and decoder
- Include basic WAV I/O, DCT, and entropy utilities with Makefile build
- Document build and usage instructions in a detailed README

## Testing
- `cd c && make`
- `cd c && ./decoder decoded.wav & ./encoder test.wav 2.0`


------
https://chatgpt.com/codex/tasks/task_e_68bade3cb6e08325b28c70a94a977b28